### PR TITLE
Decode url content if on Python 3

### DIFF
--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -222,8 +222,8 @@ def build(serviceName,
     raise HttpError(resp, content, uri=requested_url)
 
   try:
-    service = json.loads(content)
-  except ValueError as e:
+    json.loads(content)
+  except ValueError:
     logger.error('Failed to parse as JSON: ' + content)
     raise InvalidJsonError()
 

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -27,7 +27,7 @@ __all__ = ['build',
 
 from six import StringIO
 from six.moves.urllib.parse import urlencode, urlparse, urljoin,\
-      urlunparse, parse_qs, parse_qsl
+    urlunparse, parse_qsl
 
 # Standard library imports
 import copy
@@ -63,8 +63,6 @@ from googleapiclient.schema import Schemas
 from oauth2client.client import GoogleCredentials
 from oauth2client.util import _add_query_parameter
 from oauth2client.util import positional
-
-import sys
 
 # The client library requires a version of httplib2 that supports RETRIES.
 httplib2.RETRIES = 1

--- a/googleapiclient/discovery.py
+++ b/googleapiclient/discovery.py
@@ -25,6 +25,7 @@ __all__ = ['build',
            ]
 
 
+import six
 from six import StringIO
 from six.moves.urllib.parse import urlencode, urlparse, urljoin,\
     urlunparse, parse_qsl
@@ -214,6 +215,8 @@ def build(serviceName,
   logger.info('URL being requested: GET %s' % requested_url)
 
   resp, content = http.request(requested_url)
+  if six.PY3 and isinstance(content, bytes):
+    content = content.decode('utf-8')
 
   if resp.status == 404:
     raise UnknownApiNameOrVersion("name: %s  version: %s" % (serviceName,


### PR DESCRIPTION
This is a slight improvement over @chacken's pull request #1 because it also supports Python 2.6 and 2.7 using the same style of test as [google/oauth2client](https://github.com/google/oauth2client/blob/master/oauth2client/client.py#L774). Credit to him for spotting the fix!
